### PR TITLE
Carregamento e registro de Modulos por composer e local

### DIFF
--- a/src/HXPHP/System/Configs/AbstractEnvironment.php
+++ b/src/HXPHP/System/Configs/AbstractEnvironment.php
@@ -1,6 +1,8 @@
 <?php
 namespace HXPHP\System\Configs;
 
+use HXPHP\System\Tools;
+
 abstract class AbstractEnvironment
 {
     public $baseURI;
@@ -12,5 +14,55 @@ abstract class AbstractEnvironment
 
         $load = new LoadModules;
         return $load->loadModules($this);
+    }
+
+    public function registerModule(string $type, string $module, string $name = null)
+    {
+        switch ($type){
+            case 'local':
+                $module_class = Tools::filteredName(ucwords($module));
+
+                if($name){
+                    $module = $name;
+                }
+
+                if (!class_exists($module_class))
+                    throw new \Exception("O modulo local <'$module_class'> informado nao existe.", 1);
+                else
+                    $this->$module = new $module_class();
+
+                break;
+            case 'composer':
+                $module_class = Tools::filteredName(ucwords($module));
+                $object = $module_class.'\src\Config';
+
+                if($name){
+                    $module = $name;
+                }
+
+                if (!class_exists($object))
+                    throw new \Exception("O modulo composer <'$object'> informado nao existe.", 1);
+                else
+                    $this->$module = new $object();
+                break;
+        }
+
+        return $this;
+    }
+
+    public function registerModules(array $modules)
+    {
+        foreach ($modules as $module => $info){
+            $type = $info['type'] ?? '';
+            $name = $info['name'] ?? '';
+
+            if(empty($type)){
+                continue;
+            }
+
+            $data = [$type,$module,$name];
+
+            call_user_func_array([$this,'registerModule'],$data);
+        }
     }
 }

--- a/src/HXPHP/System/Controller.php
+++ b/src/HXPHP/System/Controller.php
@@ -80,34 +80,114 @@ class Controller
          * @var array
          */
         $args = func_get_args();
-        $object = $args[0];
+        $type = $args[0];
 
-        /**
-         * Define os demais argumentos passados como
-         * parâmetros para o construtor do objeto injetado
-         */
-        unset($args[0]);
-        $params = !($args) ? [] : array_values($args);
+        if(!in_array($type, ['hxphp', 'composer', 'local'])){
+            $type = 'hxphp';
+
+            $object = $args[0];
+
+            unset($args[0]);
+        } else {
+            $object = $args[1];
+
+            unset($args[0]);
+            unset($args[1]);
+        }
+
+        $args = array_values($args);
+
+        $moduleName = null;
+
+        if(isset($args[0]['name'])){
+            $moduleName = $args[0]['name'];
+            unset($args[0]);
+
+            $args = array_values($args);
+        }
 
         /**
          * Tratamento que adiciona a pasta do módulo
          */
         $explode = explode('\\', $object);
-        $object = $object . '\\' . end($explode);
-        $object = 'HXPHP\System\\' . $object;
 
-        if (class_exists($object)) {
+        if($type === 'hxphp')
+        {
+            $object = 'HXPHP\System\\' . $object;
+            $object = $object . '\\' . end($explode);
+
+            if(!$moduleName)
+                $moduleName = end($explode);
+        }
+
+        if($type === 'composer')
+        {
+            if(count($explode) == 1)
+            {
+                $module = $explode[0];
+                $object = $module.'\src\\'.$module;
+
+                if(!$moduleName)
+                    $moduleName = $module;
+
+            } else {
+                $object = implode('\\',$explode);
+
+                if(!$moduleName)
+                    $moduleName = $explode[0];
+            }
+        }
+
+        if($type === 'local')
+        {
+            if(count($explode) == 1)
+            {
+                $module = $explode[0];
+                $object = $module.'\src\\'.$module;
+
+                if(!$moduleName)
+                    $moduleName = $module;
+
+            } else {
+                $object = implode('\\',$explode);
+
+                if(!$moduleName)
+                    $moduleName = $explode[0];
+            }
+        }
+
+        /**
+         * Define os demais argumentos passados como
+         * parâmetros para o construtor do objeto injetado
+         */
+        $params = !($args) ? [] : array_values($args);
+
+        if (class_exists($object))
+        {
             $name = end($explode);
             $name = strtolower(Tools::filteredName($name));
 
-            if ($params) {
+            $enviroment = $this->configs->define->getDefault();
+            
+            if ($params)
+            {
+                var_dump($params);
                 $ref = new \ReflectionClass($object);
                 $this->view->$name = $ref->newInstanceArgs($params);
-            } else
-                $this->view->$name = new $object();
+            } else {
+
+                if(isset($this->configs->env->$enviroment->$moduleName))
+                {
+                    $this->view->$name = new $object($this->configs->env->$enviroment->$moduleName);
+                } else {
+                    $this->view->$name = new $object();
+                }
+            }
 
             return $this->view->$name;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Com essas mudanças é possível registrar módulos pelo arquivo de configuração e carregar pelo composer.

**Carregando um modulo no controller**
O código foi modificado para garantir a compatibilidade com o modelo de carregamento de módulos antigo.

O novo método **load** agora tem dois parâmetros que podem ser usados para configurar o carregamento do modulo e servico.

## Obs:
Como o metodo **load** carrega tanto modulos quanto serviços, todas as configurações abaixo são validas para os dois. Abaixo será usado o termo modulo para identificar.

##

Esses parâmetros não são obrigatórios.

Os novo parâmetros são tipo do modulo, e um array com um nome para a variável que será gerada para o modulo.

1. Tipo de modulo, valores aceitos: ```composer, hxphp, local```
Obs: O tipo hxphp é uma referencia para módulos internos e não precisa ser especificado

2. Nome da variável: É o valor que vai substituir a variável padrão com o nome do modulo gerada pelo sistema.
Obs: É necessário que seja um array com o índice **name**, caso não encontrado, será usado o modelo padrão para gerar a variável e o valor será enviado ao modulo como parâmetro.

O uso da função permanece o mesmo usando ou não esses parâmetros.

```php
<?php

class IndexController extends \HXPHP\System\Controller
{
    public function homeAction()
    {
        $this->load('tipo','modulo',['name' => 'novoNomeModulo']);
    }
}
```
 
Usando o modelo antigo, e funcional
```php
<?php

class IndexController extends \HXPHP\System\Controller
{
    public function homeAction()
    {
        $this->load('Services\Auth',
            $this->configs->auth->after_login,
            $this->configs->auth->after_logout,
            true,
            $this->request->subfolder
        );
    }
}
```

Usando o novo modo de carregamento.

```php
<?php

class IndexController extends \HXPHP\System\Controller
{
    public function homeAction()
    {
        $this->load('Services\Auth',[
            'name' => 'autenticar'
        ],
            $this->configs->auth->after_login,
            $this->configs->auth->after_logout,
            true,
            $this->request->subfolder
        );
        
    }
}
```

Usando esse novo modo os dados do modulo Auth passam a ficar acessiveis na variavel **autenticar**
```php
<?php

class IndexController extends \HXPHP\System\Controller
{
    public function homeAction()
    {
        $this->load('Services\Auth',[
            'name' => 'autenticar'
        ],
            $this->configs->auth->after_login,
            $this->configs->auth->after_logout,
            true,
            $this->request->subfolder
        );
        
        $this->autenticar->login(1,'jorge_carlos','asdasd');

    }
}
```
##  **Via composer**

Para usar modulos carregados via composer, é necessário adicionar o tipo como primeiro parâmetro do método load, no segundo parâmetro adicione o namespace do modulo.

Foi feito o teste com o modulo: [FacebookHX](https://packagist.org/packages/skay1994/facebook-hx) que foi modificado para funcionar conforme o novo padrão

É possível carregar o modulo e servico com somente o nome, caso o namespace seja composto, como por exemplo ```FacebookHX\src\FacebookHX```

Com módulos composer tambem é possivel modificar o nome da variável gerada.

E todos os parametros extras incluídos na hora de carregar o modulo são passados para o modulo

```php
<?php

class IndexController extends \HXPHP\System\Controller
{
    public function homeAction()
    {
        $this->load('composer','FacebookHX',
            ['name' => 'asdasda'],
            $this->configs->facebookHX,
            $this->configs->auth->after_login
        );
    }
}
```

## **Locais**

E para módulos que são criados localmente, todas configurações também são validas.

Um modulo local precisa ser uma classe valida.

```php
<?php

class IndexController extends \HXPHP\System\Controller
{
    public function homeAction()
    {
        $this->load('local','App\Services\Auth',[
            'name' => 'autenticar'
        ],
            $this->configs->auth->after_login,
            $this->configs->auth->after_logout,
            true,
            $this->request->subfolder
        );
    }
}
```

# Configuração automatica
Agora o sistema tenta identificar quando um modulo foi registrado no arquivo de configurações e passa esses valores para o modulo quando ele for carregado.

Obs: O sistema só vai buscar as configurações de registro caso não seja passado nenhum parâmetro durante o carregamento. Caso contrario ele vai passar os parâmetros definidos no carregamento

# Registro de Modulos / Servicos

Agora é possível registrar módulos no arquivo de configuração. O modulo não será carregado no sistema, só ficara disponível algumas opções de configuração que pode ser usadas em outros pontos do sistema.

Todos os environments tem a capacidade de registrar modulos.

O modulo precisa ter suporte para ser registrado, isso é definido se existe a classe Config em ```NOMEMUDOLO\src\Config``` caso não exista o processo não vai resultar em nenhuma alteração do sistema.

Algumas observações importantes:
1. Não é possível registrar modulos/servicos que ja vem com o framework base do HXPHP.
2. Os registros depende do seu tipo, um registro sem tipo definido vai causar erros no sistema.
3. Use somente o nome base do namespace do modulo ou vai gerar erro.

## Registrando um unico modulo/servico

Como no carregamento de módulos é possível definir o nome da variável.

Após o registro já é possível acessar os métodos disponíveis para configuração do modulo.

Você pode usar esse método quantas vezes necessário.

```php

<?php
//Constantes
$configs = new HXPHP\System\Configs\Config;
$configs->env->add('development');
$configs->env->development->registerModule('composer','FacebookHX','facebook');

$configs->env->development->facebook->facebookConfig();
```

## Registro de varios modulos.

Para registrar varios modulos existe o metodo que recebe um array com os dados do modulo.

O registro de varios modulos tem algumas exigencias.
1. **O nome da chave precisa ser o nome do modulo**
2. O conteudo do array precisa de uma chave **type**
3. A chave **name** é opcional

```php

<?php
//Constantes
$configs = new HXPHP\System\Configs\Config;
$configs->env->add('development');
$configs->env->development->registerModules([
      'FacebookHX' => [
          'type' => 'composer',
          'name' => 'facebook'
      ],
      'Modulo1' => ['type' => 'composer'],
  ]);

$configs->env->development->facebook->facebookConfig();
```